### PR TITLE
feat(renovate-config): automerge lockFileMaintenance changes

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,5 +1,10 @@
 {
   "extends": ["github>octokit/.github"],
+  "lockFileMaintenance": {
+    "automerge": true,
+    "automergeType": "branch",
+    "autoMergeStrategy": "squash"
+  },
   "packageRules": [
     {
       "matchDepTypes": [


### PR DESCRIPTION
# Description
- use 'squash' as a merge strategy (https://docs.renovatebot.com/configuration-options/#automergetype)
- merge the branch directly, do not open a PR to avoid noise to maintainers (https://docs.renovatebot.com/configuration-options/#automergetype)

# Context
Reduce noise and maintainers' time reviewing Renovate PRs