### PR TITLE
ci(workflows): add workflow to validate renovate config on PRs and push to `main`

### DIFF
--- a/.github/workflows/vaidate-renovate-config.yml
+++ b/.github/workflows/vaidate-renovate-config.yml
@@ -1,0 +1,18 @@
+name: renovate-config-validator
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.1.1
+        with:
+          config_file_path: default.json
+          strict: true


### PR DESCRIPTION
# Description
Add GitHub Action to validate Renovate's configuration on each PR and push to `main` branch.

# Resources
- https://docs.renovatebot.com/config-validation/
- https://github.com/suzuki-shunsuke/github-action-renovate-config-validator