### PR TITLE
refactor(renovate): remove unused `autoMergeStrategy` for renovate config

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,8 +2,7 @@
   "extends": ["github>octokit/.github"],
   "lockFileMaintenance": {
     "automerge": true,
-    "automergeType": "branch",
-    "autoMergeStrategy": "squash"
+    "automergeType": "branch"
   },
   "packageRules": [
     {


### PR DESCRIPTION
# Description
Remove `lockFileMaintainance.autoMergeStrategy` configuration. It is unused according to renovate's validator CLI:

```
ERROR: Found errors in configuration
       "file": "default.json",
       "errors": [
         {
           "topic": "Configuration Error",
           "message": "Invalid configuration option: lockFileMaintenance.autoMergeStrategy"
         }
       ]
```

# Resources
- https://docs.renovatebot.com/config-validation/