### PR TITLE
Add renovate.json to workflow paths

### DIFF
--- a/.github/workflows/vaidate-renovate-config.yml
+++ b/.github/workflows/vaidate-renovate-config.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - .github/workflows/vaidate-renovate-config.yml
       - default.json
+      - renovate.json
   push:
     branches:
       - main


### PR DESCRIPTION
## Description

`renovate.json` is managing the dependencies of this repository itself (the ones in GitHub Actions basically). We want to validate this config file is always well-formed.